### PR TITLE
Add basic WYSIWYG ckeditor field

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,18 @@ A textarea field is same as text but it has `rows` and `cols` properties.
 ],
 ```
 
+#### CKEditor
+
+A CKEditor is a WYSIWYG textarea field that allows you to edit & store HTML .
+
+```php
+[
+    'type' => 'ckeditor',
+    'name' => 'maintenance_note',
+    'label' => 'Maintenance note'
+],
+```
+
 #### select
 
 A select box can be defined with options:

--- a/src/resources/views/fields/ckeditor.blade.php
+++ b/src/resources/views/fields/ckeditor.blade.php
@@ -1,0 +1,22 @@
+@component('app_settings::input_group', compact('field'))
+
+    <textarea name="{{ $field['name'] }}"
+              class="{{ Arr::get( $field, 'class', config('app_settings.input_class', 'form-control')) }} ckeditor-field"
+              @if( $styleAttr = Arr::get($field, 'style')) style="{{ $styleAttr }}" @endif
+              id="{{ Arr::get($field, 'name') }}"
+    >{{ old($field['name'], \setting($field['name'])) }}</textarea>
+
+@endcomponent
+
+@once
+@push('body.scripts')
+    <script src="https://cdn.ckeditor.com/ckeditor5/22.0.0/classic/ckeditor.js"></script>
+    <script>
+      ClassicEditor
+        .create( document.querySelector( '.ckeditor-field' ) )
+        .catch( error => {
+          console.error( error );
+        } );
+    </script>
+@endpush
+@endonce

--- a/src/resources/views/layout.blade.php
+++ b/src/resources/views/layout.blade.php
@@ -8,7 +8,7 @@
     <!-- Bootstrap CSS -->
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" integrity="sha384-MCw98/SFnGE8fJT3GXwEOngsV7Zt27NXFoaoApmYm81iuXoPkFOJwJ8ERdknLPMO" crossorigin="anonymous">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css" />
-
+    @stack('head.styles')
     <title>@yield('title', 'Settings')</title>
 </head>
 <body>
@@ -21,5 +21,6 @@
 <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.3/umd/popper.min.js" integrity="sha384-ZMP7rVo3mIykV+2+9J3UJ46jBk0WLaUAdn689aCwoqbBJiSnjAK/l8WvCWPIPm49" crossorigin="anonymous"></script>
 <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.min.js" integrity="sha384-ChfqqxuZUCnJSK3+MXmPNIyE6ZbWh2IMqE241rYiqJxyMiZ6OW/JmZQ5stwEULTy" crossorigin="anonymous"></script>
+      @stack('body.scripts')
 </body>
 </html>

--- a/tests/SettingUITest.php
+++ b/tests/SettingUITest.php
@@ -29,10 +29,10 @@ class SettingUITest extends TestCase
 
         // assert
         $this->get('/settings')
-            ->assertStatus(200)
-            ->assertSee('General Settings')
-            ->assertSee('Application general settings.')
-            ->assertSee('fa fa-cog');
+             ->assertStatus(200)
+             ->assertSee('General Settings')
+             ->assertSee('Application general settings.')
+             ->assertSee('fa fa-cog');
     }
 
     /**
@@ -49,10 +49,10 @@ class SettingUITest extends TestCase
 
         // assert
         $this->get('/settings')
-            ->assertStatus(200)
-            ->assertSee('class="c-card', false)
-            ->assertSee('class="c-card-header', false)
-            ->assertSee('class="c-card-body', false);
+             ->assertStatus(200)
+             ->assertSee('class="c-card', false)
+             ->assertSee('class="c-card-header', false)
+             ->assertSee('class="c-card-body', false);
     }
 
     /**
@@ -67,8 +67,8 @@ class SettingUITest extends TestCase
 
         // assert
         $this->get('/settings')
-            ->assertStatus(200)
-            ->assertSee('Submit');
+             ->assertStatus(200)
+             ->assertSee('Submit');
     }
 
     /**
@@ -93,11 +93,11 @@ class SettingUITest extends TestCase
 
         // assert
         $this->get('/settings')
-            ->assertStatus(200)
-            ->assertSee('From Email')
-            ->assertSee('From Email of app')
-            ->assertSee('You can from email of app')
-            ->assertSee('type="text"', false);
+             ->assertStatus(200)
+             ->assertSee('From Email')
+             ->assertSee('From Email of app')
+             ->assertSee('You can from email of app')
+             ->assertSee('type="text"', false);
     }
 
     /**
@@ -122,8 +122,8 @@ class SettingUITest extends TestCase
 
         // assert
         $this->get('/settings')
-            ->assertStatus(200)
-            ->assertSee('type="email"', false);
+             ->assertStatus(200)
+             ->assertSee('type="email"', false);
     }
 
     /**
@@ -145,8 +145,8 @@ class SettingUITest extends TestCase
 
         // assert
         $this->get('/settings')
-            ->assertStatus(200)
-            ->assertSee('type="number"', false);
+             ->assertStatus(200)
+             ->assertSee('type="number"', false);
     }
 
     /**
@@ -169,9 +169,9 @@ class SettingUITest extends TestCase
 
         // assert
         $this->get('/settings')
-            ->assertStatus(200)
-            ->assertSee('select')
-            ->assertSee('IN');
+             ->assertStatus(200)
+             ->assertSee('select')
+             ->assertSee('IN');
     }
 
     /**
@@ -194,9 +194,9 @@ class SettingUITest extends TestCase
 
         // assert
         $this->get('/settings')
-            ->assertStatus(200)
-            ->assertSee('select')
-            ->assertSee('2014_10_00_000000_create_settings_table');
+             ->assertStatus(200)
+             ->assertSee('select')
+             ->assertSee('2014_10_00_000000_create_settings_table');
     }
 
     /**
@@ -218,9 +218,33 @@ class SettingUITest extends TestCase
 
         // assert
         $this->get('/settings')
-            ->assertStatus(200)
-            ->assertSee('textarea')
-            ->assertSee('message');
+             ->assertStatus(200)
+             ->assertSee('textarea')
+             ->assertSee('message');
+    }
+
+    /**
+     * it shows CKEditor input
+     *
+     * @test
+     */
+    public function it_shows_ckeditor_input()
+    {
+        // configure
+        $inputs = [
+            [
+                'type' => 'ckeditor',
+                'name' => 'html'
+            ]
+        ];
+
+        $this->configureInputs($inputs);
+
+        // assert
+        $this->get('/settings')
+             ->assertStatus(200)
+             ->assertSee('ckeditor')
+             ->assertSee('html');
     }
 
     /**
@@ -244,9 +268,9 @@ class SettingUITest extends TestCase
 
         // assert
         $this->get('/settings')
-            ->assertStatus(200)
-            ->assertSee('checkbox')
-            ->assertSee('Only Confirmed user');
+             ->assertStatus(200)
+             ->assertSee('checkbox')
+             ->assertSee('Only Confirmed user');
     }
 
     /**
@@ -273,9 +297,9 @@ class SettingUITest extends TestCase
 
         // assert
         $this->get('/settings')
-            ->assertStatus(200)
-            ->assertSee('type="radio"', false)
-            ->assertSee('Maintenance');
+             ->assertStatus(200)
+             ->assertSee('type="radio"', false)
+             ->assertSee('Maintenance');
 
 
         // configure with options to show as select
@@ -295,11 +319,11 @@ class SettingUITest extends TestCase
 
         // assert
         $this->get('/settings')
-            ->assertStatus(200)
-            ->assertSee('select')
-            ->assertSee('Yes')
-            ->assertSee('No')
-            ->assertSee('Maintenance');
+             ->assertStatus(200)
+             ->assertSee('select')
+             ->assertSee('Yes')
+             ->assertSee('No')
+             ->assertSee('Maintenance');
     }
 
     /**
@@ -322,8 +346,8 @@ class SettingUITest extends TestCase
 
         // assert
         $this->get('/settings')
-            ->assertStatus(200)
-            ->assertSee('type="file"', false);
+             ->assertStatus(200)
+             ->assertSee('type="file"', false);
     }
 
     /**
@@ -346,15 +370,15 @@ class SettingUITest extends TestCase
 
         // assert
         $this->get('/settings')
-            ->assertStatus(200)
-            ->assertSee('type="file"', false);
+             ->assertStatus(200)
+             ->assertSee('type="file"', false);
     }
-    
+
     /**
-    * it overrides input group class
-    * 
-    * @test
-    */
+     * it overrides input group class
+     *
+     * @test
+     */
     public function it_overrides_input_group_class()
     {
         config(['app_settings.input_wrapper_class' => 'new-input-wrapper']);
@@ -362,9 +386,9 @@ class SettingUITest extends TestCase
         $this->withoutExceptionHandling();
         // assert
         $this->get('/settings')
-            ->assertStatus(200)
-            ->assertSee('class="new-input-wrapper', false)
-            ->assertDontSee('class="input-group');
+             ->assertStatus(200)
+             ->assertSee('class="new-input-wrapper', false)
+             ->assertDontSee('class="input-group');
     }
 
     /**
@@ -387,8 +411,8 @@ class SettingUITest extends TestCase
 
         // assert
         $this->get('/settings')
-            ->assertStatus(200)
-            ->assertSee('future_input')
-            ->assertSee('not supported');
+             ->assertStatus(200)
+             ->assertSee('future_input')
+             ->assertSee('not supported');
     }
 }


### PR DESCRIPTION
Adds  [classic implementation of CKEditor 5](https://ckeditor.com/docs/ckeditor5/latest/examples/builds/classic-editor.html)

_P.S: I had to amend the layout file to allow fields including pushing CSS / JS to the layout._