### PR TITLE
Refactor of AppSetting storage to allow extension

### DIFF
--- a/src/Setting/AppSettings.php
+++ b/src/Setting/AppSettings.php
@@ -32,13 +32,12 @@ class AppSettings
      */
     public function setSettingStorage(SettingStorage $settingStorage)
     {
-        $groupName = $this->getSettingsGroupName();
+        $this->settingStorage = $settingStorage;
 
+        $groupName = $this->getSettingsGroupName();
         if( $groupName && is_callable($groupName) ) {
             $groupName = $this->runCallback($groupName, 'setting_group', null);
-            $this->settingStorage = $settingStorage->group($groupName);
-        } else {
-            $this->settingStorage = $settingStorage;
+            $this->settingStorage->group($groupName);
         }
     }
 

--- a/src/Setting/AppSettings.php
+++ b/src/Setting/AppSettings.php
@@ -43,6 +43,16 @@ class AppSettings
     }
 
     /**
+     * Sets the current storage group.
+     *
+     * @param string $groupName
+     */
+    public function setStorageGroup($groupName)
+    {
+        $this->settingStorage->group($groupName);
+    }
+
+    /**
      * Get al the settings from storage
      *
      * @param bool $fresh

--- a/src/Setting/AppSettings.php
+++ b/src/Setting/AppSettings.php
@@ -22,7 +22,7 @@ class AppSettings
      */
     public function __construct(SettingStorage $settingStorage)
     {
-		$this->setSettingStorage($settingStorage);
+        $this->setSettingStorage($settingStorage);
     }
 
     /**

--- a/src/Setting/AppSettings.php
+++ b/src/Setting/AppSettings.php
@@ -37,7 +37,7 @@ class AppSettings
         $groupName = $this->getSettingsGroupName();
         if( $groupName && is_callable($groupName) ) {
             $groupName = $this->runCallback($groupName, 'setting_group', null);
-            $this->settingStorage->group($groupName);
+            $this->setStorageGroup($groupName);
         }
     }
 

--- a/src/Setting/AppSettings.php
+++ b/src/Setting/AppSettings.php
@@ -13,7 +13,7 @@ class AppSettings
     /**
      * @var SettingStorage
      */
-    private $settingStorage;
+    protected $settingStorage;
 
     /**
      * AppSettings constructor.
@@ -214,7 +214,7 @@ class AppSettings
      * @param bool $out
      * @return bool|int|mixed|string
      */
-    private function castValue($dataType, $value, $out = false)
+    protected function castValue($dataType, $value, $out = false)
     {
         switch ($dataType) {
             case 'array':
@@ -285,7 +285,7 @@ class AppSettings
      * @param $out
      * @return array|mixed|string
      */
-    private function castToArray($value, $out)
+    protected function castToArray($value, $out)
     {
         if ($out) {
             return empty($value) ? [] : json_decode($value, true);
@@ -301,7 +301,7 @@ class AppSettings
      * @param $request Request
      * @return string|null
      */
-    private function uploadFile($setting, $request)
+    protected function uploadFile($setting, $request)
     {
         $settingName = Arr::get($setting, 'name');
 
@@ -337,7 +337,7 @@ class AppSettings
      * @param $oldFile
      * @param $disk
      */
-    private function deleteFile($oldFile, $disk): void
+    protected function deleteFile($oldFile, $disk): void
     {
         if ($oldFile && Storage::disk($disk)->exists($oldFile)) {
             Storage::disk($disk)->delete($oldFile);

--- a/src/Setting/AppSettings.php
+++ b/src/Setting/AppSettings.php
@@ -22,6 +22,16 @@ class AppSettings
      */
     public function __construct(SettingStorage $settingStorage)
     {
+		$this->setSettingStorage($settingStorage);
+    }
+
+    /**
+     * Sets the settings storage.
+     *
+     * @param SettingStorage $settingStorage
+     */
+    public function setSettingStorage(SettingStorage $settingStorage)
+    {
         $groupName = $this->getSettingsGroupName();
 
         if( $groupName && is_callable($groupName) ) {


### PR DESCRIPTION
I had severe issues trying to extend the `AppSetting` class due to the amount of private methods.
For this reason I decided to change all methods from private to protected.
Additionally I refactored the constructor and moved the storage group init in a separate function that can be called when you need to redefine the storage group name.
In my case I had a problem with multitenant Queues (using the library https://github.com/tenancy/multi-tenant).
The group was defined once for queue and all tenant jobs were called using the first defined setting group.

To change the setting group at runtime you can call this function:
`app('app-settings')->setStorageGroup('my-storage-group')`